### PR TITLE
[Fix] Load data will have wrong newCourtId issue

### DIFF
--- a/src/components/EditMode/CourtTabs.js
+++ b/src/components/EditMode/CourtTabs.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Flex, IconButton } from '@chakra-ui/core';
+import { useCourtState, useCourtDispatch } from '../../hooks/court';
 import { useCourtPositionsState, useCourtPositionsDispatch } from '../../hooks/courtPositions';
 import CourtTab from './CourtTab';
 
@@ -9,13 +10,14 @@ const renderTabs = (courtPositions) =>
   ));
 
 function CourtTabs() {
-  const [newCourtId, setCourtId] = React.useState(3);
+  const { newCourtId } = useCourtState();
+  const courtDispatch = useCourtDispatch();
   const courtPositions = useCourtPositionsState();
   const courtPositionsDispatch = useCourtPositionsDispatch();
 
   const handleAddCourt = () => {
     courtPositionsDispatch({ type: 'ADD_COURT', id: newCourtId });
-    setCourtId((prev) => prev + 1);
+    courtDispatch({ type: 'ADD_COURT' });
   };
 
   return (

--- a/src/constants/base.js
+++ b/src/constants/base.js
@@ -28,7 +28,7 @@ export const PLAYER_POSITION = {
 
 export const DEFAULT_COURT = {
   selectedPosition: null,
-  newCourtId: 3,
+  newCourtId: '3',
   currentCourt: '1',
   selectedCourts: ['1'],
   playerInfo: {

--- a/src/hooks/court.js
+++ b/src/hooks/court.js
@@ -32,7 +32,7 @@ function courtReducer(state, action) {
     case 'ADD_COURT': {
       return {
         ...state,
-        newCourtId: state.newCourtId + 1,
+        newCourtId: `${parseInt(state.newCourtId, 10) + 1}`,
       };
     }
     case 'DELETE_COURT': {


### PR DESCRIPTION
### Description
* Since I save data with `court` context but I use local state `newCourtId` to display `CourtTab`, this will cause issue when load the data.
* Use `courtDispatch` to update `newCourtId` rather than `setNewCourtId`